### PR TITLE
Setting reconstruct and error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "ibig",
+ "once_cell",
+ "regex",
  "toml",
  "xlsxwriter",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,3 +8,5 @@ clap = { version = "4.5.4", features = ["derive"] }
 ibig = "0.3.6"
 xlsxwriter = "0.6.1"
 toml = "0.8.14"
+regex = "1.10.5"
+once_cell = "1.19.0"

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,0 +1,84 @@
+/* Str2table core crate for error types
+ * Copyright (C) 2024 Peng Zijun
+ *
+ * This file is part of Str2table.
+ * Foobar is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * Str2table is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with Foobar.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+//! Error types for Str2table
+pub mod arg_error;
+pub mod conflicts;
+pub mod keyword_missing;
+pub mod range_error;
+
+/// A enum to describe the level of an error
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum ErrorLevel {
+    /// Error that can be ignore or fixed automatically
+    Warning,
+    /// Error that can be fixed by user, e.g. recall the command
+    Error,
+    /// Error that caused by unrecovable reasons, e.g. file not found
+    Fatal,
+}
+
+impl ToString for ErrorLevel {
+    fn to_string(&self) -> String {
+        match self {
+            ErrorLevel::Warning => "[Warning]",
+            ErrorLevel::Error => "[Error]",
+            ErrorLevel::Fatal => "[Fatal]",
+        }
+        .to_string()
+    }
+}
+
+/// A trait for Error types in this project
+pub trait ErrorType: std::error::Error {
+    /// Get the general description of this Error
+    fn describe(&self) -> String;
+    /// Get the level of this Error
+    fn level(&self) -> ErrorLevel;
+    /// Get the specific reason of this Error
+    fn reason(&self) -> Option<String>;
+    /// Get the attempt that program has already take to fix this error
+    fn attempt(&self) -> Option<String>;
+    /// Get the hint for user to fix this error
+    fn hint(&self) -> Option<String>;
+    /// Get the message to show on the screen
+    fn message(&self, showing_level: ErrorLevel) -> String {
+        let mut message = self.level().to_string();
+        message.push_str(self.describe().as_str());
+
+        if let Some(attempt) = self.attempt() {
+            message.push_str(&format!(
+                "\nProgram has tried this(these) attempt to fix this error:\n\t {}",
+                attempt
+            ));
+        }
+        if let Some(hint) = self.hint() {
+            message.push_str(&format!(
+                "\nYou may try the following method(s) to fix this:\n\t {} ",
+                hint
+            ));
+        }
+        if let Some(reason) = self.reason() {
+            message.push_str(&format!(
+                "\nThis error is caused by the following reason(s):\n {}",
+                reason
+            ));
+        }
+        if self.level() >= showing_level {
+            message
+        } else {
+            "".to_string()
+        }
+    }
+}

--- a/core/src/error/arg_error.rs
+++ b/core/src/error/arg_error.rs
@@ -1,0 +1,148 @@
+/* Str2table core crate for error types
+ * Copyright (C) 2024 Peng Zijun
+ *
+ * This file is part of Str2table.
+ * Foobar is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * Str2table is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with Foobar.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+//! ArgError is a error type that is used to describe the error in the commandline arguments.
+use super::{ErrorLevel, ErrorType};
+
+pub struct ArgError {
+    pub name: String,
+    pub description: String,
+    pub level: ErrorLevel,
+    pub reason: Option<String>,
+    pub error_arg: Option<String>,
+    pub whole_arg: Option<String>,
+    pub error_location: Option<(usize, usize)>,
+    pub hint: Option<String>,
+}
+
+pub enum ArgErrorKind {
+    NoImplementation,
+    WrongFormat,
+    Conflicts,
+    FormatError,
+}
+
+impl ToString for ArgErrorKind {
+    fn to_string(&self) -> String {
+        match self {
+            ArgErrorKind::NoImplementation => "NoImplementation".to_string(),
+            ArgErrorKind::WrongFormat => "WrongFormat".to_string(),
+            ArgErrorKind::Conflicts => "Conflicts".to_string(),
+            ArgErrorKind::FormatError => "FormatError".to_string(),
+        }
+    }
+}
+
+impl ArgErrorKind {
+    pub fn get_description(&self) -> String {
+        match self {
+            ArgErrorKind::NoImplementation => "This argument is not implemented fully.".to_string(),
+            ArgErrorKind::WrongFormat => "The format of this argument is wrong.".to_string(),
+            ArgErrorKind::Conflicts => "This argument causes conflict(s)".to_string(),
+            ArgErrorKind::FormatError => "This file format is unsupported.".to_string(),
+        }
+    }
+    pub fn get_hint(&self) -> Option<String> {
+        match self {
+            ArgErrorKind::NoImplementation => Some("Please wait for the next version.".to_string()),
+            ArgErrorKind::WrongFormat => {
+                Some("Please check the format of this argument.".to_string())
+            }
+            ArgErrorKind::Conflicts => Some("Please check the reason.".to_string()),
+            ArgErrorKind::FormatError => Some("Please check the format of the file.".to_string()),
+        }
+    }
+    pub fn get_level(&self) -> ErrorLevel {
+        match self {
+            ArgErrorKind::NoImplementation => ErrorLevel::Warning,
+            ArgErrorKind::WrongFormat => ErrorLevel::Error,
+            ArgErrorKind::Conflicts => ErrorLevel::Error,
+            ArgErrorKind::FormatError => ErrorLevel::Error,
+        }
+    }
+}
+
+impl ArgError {
+    pub fn new(
+        error_type: ArgErrorKind,
+        reason: Option<String>,
+        error_arg: Option<String>,
+        whole_arg: Option<String>,
+        error_location: Option<(usize, usize)>,
+        hint: Option<String>,
+    ) -> ArgError {
+        let name = error_type.to_string();
+        let description = error_type.get_description();
+        let hint_ = error_type.get_hint();
+        let level = error_type.get_level();
+        ArgError {
+            name,
+            description,
+            level,
+            reason,
+            error_arg,
+            whole_arg,
+            error_location,
+            hint: if hint.is_none() { hint } else { hint_ },
+        }
+    }
+}
+
+impl ErrorType for ArgError {
+    fn describe(&self) -> String {
+        self.description.clone()
+    }
+    fn attempt(&self) -> Option<String> {
+        None
+    }
+    fn reason(&self) -> Option<String> {
+        if self.reason.is_none() {
+            return None;
+        }
+        let mut reason = "Error happens in \"".to_string();
+        reason.push_str(self.whole_arg.as_ref().unwrap().as_str());
+        reason.push_str("\", where");
+        if self.error_arg.is_some() {
+            reason.push_str(" \"");
+            reason.push_str(self.error_arg.as_ref().unwrap().as_str());
+            reason.push_str("\" ");
+        }
+        reason.push_str(self.reason.as_ref().unwrap().as_str());
+        Some(reason)
+    }
+    fn hint(&self) -> Option<String> {
+        self.hint.clone()
+    }
+    fn level(&self) -> ErrorLevel {
+        self.level
+    }
+}
+
+impl std::error::Error for ArgError {
+    fn description(&self) -> &str {
+        self.description.as_str()
+    }
+}
+
+impl std::fmt::Display for ArgError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.message(ErrorLevel::Warning))
+    }
+}
+
+impl std::fmt::Debug for ArgError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.message(ErrorLevel::Warning))
+    }
+}

--- a/core/src/error/conflicts.rs
+++ b/core/src/error/conflicts.rs
@@ -1,0 +1,144 @@
+/* Str2table core crate for error types
+ * Copyright (C) 2024 Peng Zijun
+ *
+ * This file is part of Str2table.
+ * Foobar is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * Str2table is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with Foobar.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+//! Conflicts is a error type that is used to describe the error of conflicts in commandlines
+//! and maybe other places.
+use super::{ErrorLevel, ErrorType};
+
+pub struct Conflicts {
+    pub name: String,
+    pub description: String,
+    pub level: ErrorLevel,
+    pub reason: Option<String>,
+    pub error_arg: Option<String>,
+    pub whole_arg: Option<String>,
+    pub error_location: Option<(usize, usize)>,
+    pub hint: Option<String>,
+}
+
+impl Conflicts {
+    pub fn new(
+        level: ErrorLevel,
+        error_arg: Option<String>,
+        whole_arg: Option<String>,
+        error_location: Option<(usize, usize)>,
+        conflicts_vec: Option<Vec<String>>,
+    ) -> Self {
+        let mut flag = 0;
+        if error_arg.is_some() {
+            flag += 1;
+        }
+        if conflicts_vec.is_some() {
+            flag += 2;
+        }
+        let name = "ConflictsError".to_string();
+        let description = "This argument causes conflict(s).".to_string();
+        let hint = Some("Please check the conflict(s) and try again.".to_string());
+        match flag {
+            0 => Self {
+                name,
+                description,
+                level,
+                reason: None,
+                error_arg,
+                whole_arg,
+                error_location,
+                hint,
+            },
+            1 => Self {
+                name,
+                description,
+                level,
+                reason: {
+                    let error_arg = error_arg.clone().unwrap();
+                    Some(format!("{error_arg} has conflicts in it.").to_string())
+                },
+                error_arg,
+                whole_arg,
+                error_location,
+                hint,
+            },
+            2 => Self {
+                name,
+                description,
+                level,
+                reason: {
+                    let conflicts_vec = conflicts_vec.unwrap();
+                    Some(format!("{:?} conflict with each other.", conflicts_vec).to_string())
+                },
+                error_arg,
+                whole_arg,
+                error_location,
+                hint,
+            },
+            3 => Self {
+                name,
+                description,
+                level,
+                reason: {
+                    let error_arg = error_arg.clone().unwrap();
+                    let conflicts_vec = conflicts_vec.unwrap();
+                    Some(
+                        format!(
+                            "In {error_arg}, {:?} conflict with each other.",
+                            conflicts_vec
+                        )
+                        .to_string(),
+                    )
+                },
+                error_arg,
+                whole_arg,
+                error_location,
+                hint,
+            },
+            _ => panic!("fatal error!"),
+        }
+    }
+}
+
+impl ErrorType for Conflicts {
+    fn attempt(&self) -> Option<String> {
+        None
+    }
+    fn describe(&self) -> String {
+        self.description.clone()
+    }
+    fn hint(&self) -> Option<String> {
+        self.hint.clone()
+    }
+    fn level(&self) -> ErrorLevel {
+        self.level
+    }
+    fn reason(&self) -> Option<String> {
+        self.reason.clone()
+    }
+}
+
+impl std::error::Error for Conflicts {
+    fn description(&self) -> &str {
+        self.description.as_str()
+    }
+}
+
+impl std::fmt::Display for Conflicts {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.message(ErrorLevel::Error))
+    }
+}
+
+impl std::fmt::Debug for Conflicts {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.message(ErrorLevel::Error))
+    }
+}

--- a/core/src/error/keyword_missing.rs
+++ b/core/src/error/keyword_missing.rs
@@ -1,0 +1,99 @@
+/* Str2table core crate for error types
+ * Copyright (C) 2024 Peng Zijun
+ *
+ * This file is part of Str2table.
+ * Foobar is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * Str2table is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with Foobar.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+//! keyword_missing is a error type that is used to describe the error in the keyword missing.
+use super::{ErrorLevel, ErrorType};
+
+pub struct KeywordMissing {
+    pub name: String,
+    pub description: String,
+    pub level: ErrorLevel,
+    pub reason: Option<String>,
+    pub error_arg: Option<String>,
+    pub whole_arg: Option<String>,
+    pub error_location: Option<(usize, usize)>,
+    pub hint: Option<String>,
+}
+
+impl KeywordMissing {
+    pub fn new(
+        error_arg: Option<String>,
+        whole_arg: Option<String>,
+        error_location: Option<(usize, usize)>,
+        keyword: String,
+    ) -> Self {
+        let name = "KeywordError".to_string();
+        let description = format!("{} is missing or wrong.", keyword);
+        let hint = Some("Please check the keyword and try again.".to_string());
+        let level = ErrorLevel::Error;
+        let reason = if error_arg.is_none() {
+            None
+        } else {
+            Some(format!(
+                "In {} where {} is expected.",
+                whole_arg.as_ref().unwrap(),
+                keyword
+            ))
+        };
+        Self {
+            name,
+            description,
+            level,
+            reason,
+            error_arg,
+            whole_arg,
+            error_location,
+            hint,
+        }
+    }
+}
+
+impl ErrorType for KeywordMissing {
+    fn attempt(&self) -> Option<String> {
+        None
+    }
+    fn describe(&self) -> String {
+        self.description.clone()
+    }
+
+    fn level(&self) -> ErrorLevel {
+        self.level
+    }
+
+    fn reason(&self) -> Option<String> {
+        self.reason.clone()
+    }
+
+    fn hint(&self) -> Option<String> {
+        self.hint.clone()
+    }
+}
+
+impl std::error::Error for KeywordMissing {
+    fn description(&self) -> &str {
+        self.description.as_str()
+    }
+}
+
+impl std::fmt::Display for KeywordMissing {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.message(ErrorLevel::Error))
+    }
+}
+
+impl std::fmt::Debug for KeywordMissing {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.message(ErrorLevel::Error))
+    }
+}

--- a/core/src/error/range_error.rs
+++ b/core/src/error/range_error.rs
@@ -1,0 +1,134 @@
+/* Str2table core crate for error types
+ * Copyright (C) 2024 Peng Zijun
+ *
+ * This file is part of Str2table.
+ * Foobar is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * Str2table is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with Foobar.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+//! RangeError is a error type that is used to describe the error in the range of a value.
+use super::{ErrorLevel, ErrorType};
+
+pub enum RangeErrorKind {
+    OutOfRange,
+    LeftSideError,
+    RightSideError,
+    BothSidesError,
+    SingleNumberError,
+}
+
+impl ToString for RangeErrorKind {
+    fn to_string(&self) -> String {
+        match self {
+            RangeErrorKind::OutOfRange => "OutOfRange".to_string(),
+            RangeErrorKind::LeftSideError => "LeftSideError".to_string(),
+            RangeErrorKind::RightSideError => "RightSideError".to_string(),
+            RangeErrorKind::BothSidesError => "BothSidesError".to_string(),
+            RangeErrorKind::SingleNumberError => "SingleNumberError".to_string(),
+        }
+    }
+}
+
+impl RangeErrorKind {
+    pub fn get_reason(&self) -> String {
+        match self {
+            RangeErrorKind::OutOfRange => "the value is out of the range.".to_string(),
+            RangeErrorKind::LeftSideError => {
+                "the left side of the range is missing or not a number.".to_string()
+            }
+            RangeErrorKind::RightSideError => {
+                "the right side of the range is missing or not a number.".to_string()
+            }
+            RangeErrorKind::BothSidesError => {
+                "both sides of the range are missing or not a number.".to_string()
+            }
+            RangeErrorKind::SingleNumberError => {
+                "the single number is missing or not a number.".to_string()
+            }
+        }
+    }
+}
+
+pub struct RangeError {
+    pub name: String,
+    pub description: String,
+    pub level: ErrorLevel,
+    pub reason: Option<String>,
+    pub error_value: Option<String>,
+    pub whole_value: Option<String>,
+    pub error_location: Option<(usize, usize)>,
+    pub hint: Option<String>,
+}
+
+impl RangeError {
+    pub fn new(
+        error_type: RangeErrorKind,
+        error_value: Option<String>,
+        whole_value: Option<String>,
+        error_location: Option<(usize, usize)>,
+    ) -> Self {
+        Self {
+            name: "RangeError".to_string(),
+            description: error_type.to_string(),
+            level: ErrorLevel::Error,
+            reason: Some(error_type.get_reason()),
+            error_value,
+            whole_value,
+            error_location,
+            hint: Some("Please check the ragne again.".to_string()),
+        }
+    }
+}
+
+impl ErrorType for RangeError {
+    fn describe(&self) -> String {
+        self.description.clone()
+    }
+
+    fn level(&self) -> ErrorLevel {
+        self.level
+    }
+
+    fn reason(&self) -> Option<String> {
+        if self.reason.is_none() {
+            return None;
+        }
+        let mut reason = "Error happens in \"".to_string();
+        reason.push_str(self.error_value.as_ref().unwrap().as_str());
+        reason.push_str("\", where ");
+        reason.push_str(self.reason.as_ref().unwrap().as_str());
+        Some(reason)
+    }
+
+    fn attempt(&self) -> Option<String> {
+        None
+    }
+
+    fn hint(&self) -> Option<String> {
+        self.hint.clone()
+    }
+}
+
+impl std::error::Error for RangeError {
+    fn description(&self) -> &str {
+        self.description.as_str()
+    }
+}
+
+impl std::fmt::Display for RangeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message(ErrorLevel::Warning))
+    }
+}
+
+impl std::fmt::Debug for RangeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message(ErrorLevel::Warning))
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
+pub mod error;
 pub mod export;
 pub mod setting;
 pub mod table;

--- a/core/src/setting/core.rs
+++ b/core/src/setting/core.rs
@@ -1,6 +1,22 @@
+use std::str::FromStr;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// A enum to specify the line or column, used in force parce and output color
 pub enum LineColumn {
     Line,
     Column,
+}
+
+impl FromStr for LineColumn {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "l" => Ok(LineColumn::Line),
+            "c" => Ok(LineColumn::Column),
+            "L" => Ok(LineColumn::Line),
+            "C" => Ok(LineColumn::Column),
+            "Line" => Ok(LineColumn::Line),
+            "Column" => Ok(LineColumn::Column),
+            _ => Err(()),
+        }
+    }
 }

--- a/core/src/setting/input.rs
+++ b/core/src/setting/input.rs
@@ -275,7 +275,7 @@ fn parse_single_force(
     let start = caps["start"].parse::<usize>().unwrap();
     let lc = LineColumn::from_str(&caps["lc"]).unwrap();
     let force_type = ForceType::from_str(&caps["type"]).unwrap();
-    if Some(lc) != linecolumn {
+    if Some(lc) != linecolumn && linecolumn.is_some() {
         let conflict = Conflicts::new(
             ErrorLevel::Error,
             Some(part.to_string()),
@@ -310,7 +310,7 @@ fn parse_range_force(
     let end = caps["end"].parse::<usize>().unwrap();
     let lc = LineColumn::from_str(&caps["lc"]).unwrap();
     let force_type = ForceType::from_str(&caps["type"]).unwrap();
-    if Some(lc) != linecolumn {
+    if Some(lc) != linecolumn && linecolumn.is_some() {
         let conflict = Conflicts::new(
             ErrorLevel::Error,
             Some(part.to_string()),

--- a/core/src/setting/output.rs
+++ b/core/src/setting/output.rs
@@ -12,8 +12,17 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
+use std::str::FromStr;
+
+use crate::error::arg_error::{ArgError, ArgErrorKind};
+use crate::error::keyword_missing::KeywordMissing;
+use crate::error::range_error::{RangeError, RangeErrorKind};
+use crate::error::{ErrorLevel, ErrorType};
+use crate::setting::LineColumn;
 use clap::Parser;
 use clap::*;
+use once_cell::sync::Lazy;
+use regex::{Regex, RegexSet};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 /// A enum to specify the output format,
@@ -34,6 +43,21 @@ pub enum OutputColor {
     Yellow,
     Grey,
     White,
+}
+
+impl FromStr for OutputColor {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "r" | "R" => Ok(OutputColor::Red),
+            "g" | "G" => Ok(OutputColor::Green),
+            "b" | "B" => Ok(OutputColor::Blue),
+            "y" | "Y" => Ok(OutputColor::Yellow),
+            "x" | "X" => Ok(OutputColor::Grey),
+            "w" | "W" => Ok(OutputColor::White),
+            _ => Err(()),
+        }
+    }
 }
 
 impl std::fmt::Display for OutputColor {
@@ -80,7 +104,13 @@ pub struct OutputSettings {
 
     #[arg(short = 'C', long, value_parser = validate_export_color)]
     /// Set the color of the table by line, enable when export mode is console
+    /// ((line, color), (column, color))
     pub export_color: Option<(Vec<(usize, OutputColor)>, Vec<(usize, OutputColor)>)>,
+
+    #[arg(short = 'S', long, value_parser = validate_export_subtable)]
+    /// Use a number or range end with `l/c` to specify the line or column
+    /// Export the subtable of the cross parts of the lines and columns
+    pub export_subtable: Option<(Vec<usize>, Vec<usize>)>,
 }
 
 impl Default for OutputSettings {
@@ -88,11 +118,12 @@ impl Default for OutputSettings {
         OutputSettings {
             output: None,
             export_color: None,
+            export_subtable: None,
         }
     }
 }
 
-fn validate_output(s: &str) -> Result<(String, OutputFormat), String> {
+fn validate_output(s: &str) -> Result<(String, OutputFormat), ArgError> {
     // Get the file format from suffix
     let parts: Vec<&str> = s.split('.').collect();
     let format = match parts[parts.len() - 1] {
@@ -100,9 +131,13 @@ fn validate_output(s: &str) -> Result<(String, OutputFormat), String> {
         "txt" => OutputFormat::Txt,
         "xls" | "xlsx" => OutputFormat::Exls,
         _ => {
-            return Err(format!(
-                "Unsupported file format '\x1b[1;31m{}\x1b[0m'",
-                parts[parts.len() - 1]
+            return Err(ArgError::new(
+                ArgErrorKind::FormatError,
+                Some("The format of the file is not supported.".to_string()),
+                Some(parts[parts.len() - 1].to_string()),
+                Some(s.to_string()),
+                None,
+                None,
             ))
         }
     };
@@ -110,160 +145,351 @@ fn validate_output(s: &str) -> Result<(String, OutputFormat), String> {
     Ok((s.to_string(), format))
 }
 
+fn validate_export_subtable(s: &str) -> Result<(Vec<usize>, Vec<usize>), ArgError> {
+    // regex to check if input is valid
+    let regex_set = RegexSet::new(&[
+        // 0. correct range
+        r"^[0-9]+-[0-9]+[lcLC]$",
+        // 1. correct single
+        r"^[0-9]+[lcLC]$",
+        // 2. wrong format in left side of range
+        r"^.*-[0-9]+[lcLC]$",
+        // 3. wrong format in right side of range
+        r"^[0-9]+-.*[lcLC]$",
+        // 4. wrong format in both sides of range
+        r"^.*-.*[lcLC]$",
+        // 5. wrong format in single
+        r"^.*[lcLC]$",
+        // 6. wrong format in line/column (range)
+        r"^[0-9]+-[0-9]+.*$",
+        // 7. wrong format in line/column (single)
+        r"^[0-9]+.*$",
+    ])
+    .unwrap();
+
+    let mut lines: Vec<usize> = Vec::new();
+    let mut columns: Vec<usize> = Vec::new();
+
+    // split the target string into parts
+    let parts = s.split(',');
+
+    // track the location of the part
+    let mut location = 0;
+
+    // iterate through the parts
+    for part in parts {
+        let matches = regex_set.matches(part).into_iter().collect::<Vec<_>>();
+        if matches.is_empty() {
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some("There is more than one error in this part".to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        } else if matches[0] == 0 {
+            let ((start, end), lc) = parse_range_subtable(part);
+            match lc {
+                LineColumn::Line => {
+                    for i in start..=end {
+                        lines.push(i);
+                    }
+                }
+                LineColumn::Column => {
+                    for i in start..=end {
+                        columns.push(i);
+                    }
+                }
+            }
+        } else if matches[0] == 1 {
+            let (num, lc) = parse_single_subtable(part);
+            match lc {
+                LineColumn::Line => {
+                    lines.push(num);
+                }
+                LineColumn::Column => {
+                    columns.push(num);
+                }
+            }
+        } else if matches[0] == 2 {
+            let range_error = RangeError::new(
+                RangeErrorKind::LeftSideError,
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+            );
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some(range_error.message(ErrorLevel::Warning).to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        } else if matches[0] == 3 {
+            let range_error = RangeError::new(
+                RangeErrorKind::RightSideError,
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+            );
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some(range_error.message(ErrorLevel::Warning).to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        } else if matches[0] == 4 {
+            let range_error = RangeError::new(
+                RangeErrorKind::BothSidesError,
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+            );
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some(range_error.message(ErrorLevel::Warning).to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        } else if matches[0] == 5 {
+            let range_error = RangeError::new(
+                RangeErrorKind::SingleNumberError,
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+            );
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some(range_error.message(ErrorLevel::Warning).to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        } else if matches[0] == 6 || matches[0] == 7 {
+            let keyword_missing = KeywordMissing::new(
+                Some("line/column".to_string()),
+                Some("export_subtable".to_string()),
+                Some((location, location + part.len())),
+                "line or column".to_string(),
+            );
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some(keyword_missing.message(ErrorLevel::Warning).to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        }
+        location += part.len();
+    }
+    Ok((lines, columns))
+}
+
 fn validate_export_color(
     s: &str,
-) -> Result<(Vec<(usize, OutputColor)>, Vec<(usize, OutputColor)>), String> {
+) -> Result<(Vec<(usize, OutputColor)>, Vec<(usize, OutputColor)>), ArgError> {
+    let regex_set = RegexSet::new(&[
+        // 0. correct range
+        r"^[0-9]+-[0-9]+[rgbyxwRGYBXW][lcLC]$",
+        // 1. correct single
+        r"^[0-9]+[rgbyxwRGYBXW][lcLC]$",
+        // 2. wrong format in left side of range
+        r"^.*-[0-9]+[rgbyxwRGYBXW][lcLC]$",
+        // 3. wrong format in right side of range
+        r"^[0-9]+-.*[rgbyxwRGYBXW][lcLC]$",
+        // 4. wrong format in both sides of range
+        r"^.*-.*[rgbyxwRGYBXW][lcLC]$",
+        // 5. wrong format in single
+        r"^.*[rgbyxwRGYBXW][lcLC]$",
+        // 6. wrong format in line/column (range)
+        r"^[0-9]+-[0-9]+[rgbyxwRGBYXW].*$",
+        // 7. wrong format in line/column (single)
+        r"^[0-9]+[rgbyxwRGBYXW].*$",
+        // 8. wrong format in color
+        r"^[0-9]+-[0-9]+.*[lcLC]$",
+    ])
+    .unwrap();
+    let mut lines: Vec<(usize, OutputColor)> = Vec::new();
+    let mut columns: Vec<(usize, OutputColor)> = Vec::new();
+
     let parts = s.split(',');
-    let mut line: Vec<(usize, OutputColor)> = Vec::new();
-    let mut column: Vec<(usize, OutputColor)> = Vec::new();
+    let mut location = 0;
+
     for part in parts {
-        // if part is a range
-        if part.contains('-') {
-            let range = part.split('-').collect::<Vec<&str>>();
-            // parse start of range
-            let start: usize;
-            match range[0].parse::<usize>() {
-                Ok(n) => start = n,
-                Err(e) => {
-                    return Err(format!(
-                        "'\x1b[1;31m{}\x1b[0m' has {}",
-                        range[0],
-                        e.to_string()
-                    ))
+        let matches = regex_set.matches(part).into_iter().collect::<Vec<_>>();
+        if matches.is_empty() {
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some("There is more than one error in this part".to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        } else if matches[0] == 0 {
+            let ((start, end), color, lc) = parse_range_color(part);
+            match lc {
+                LineColumn::Line => {
+                    for i in start..=end {
+                        lines.push((i, color));
+                    }
+                }
+                LineColumn::Column => {
+                    for i in start..=end {
+                        columns.push((i, color));
+                    }
                 }
             }
-
-            // parse end of range
-            let end: usize;
-            let color: OutputColor;
-
-            if range[1].len() <= 2 {
-                return Err(format!("'\x1b[1;31m{}\x1b[0m' invalid format", part));
-            }
-
-            let last = range[1].chars().last();
-            let second_last = range[1].chars().nth(range[1].len() - 2);
-            let is_line: bool;
-
-            match second_last {
-                Some('l') => is_line = true,
-                Some('c') => is_line = false,
-                Some(_) => {
-                    return Err(format!(
-                        "'\x1b[1;31m{}\x1b[0m' should end with 'l' or 'c'",
-                        range[1]
-                    ))
+        } else if matches[0] == 1 {
+            let (num, color, lc) = parse_single_color(part);
+            match lc {
+                LineColumn::Line => {
+                    lines.push((num, color));
                 }
-                None => {
-                    return Err(format!(
-                        "'\x1b[1;31m{}\x1b[0m' lack of 'l' or 'c' to specify line or column",
-                        range[1]
-                    ))
+                LineColumn::Column => {
+                    columns.push((num, color));
                 }
             }
-
-            match last {
-                Some('r') => color = OutputColor::Red,
-                Some('g') => color = OutputColor::Green,
-                Some('b') => color = OutputColor::Blue,
-                Some('y') => color = OutputColor::Yellow,
-                Some('x') => color = OutputColor::Grey,
-                Some('w') => color = OutputColor::White,
-                _ => {
-                    return Err(format!(
-                    "'\x1b[1;31m{}\x1b[0m' should end with color 'r', 'g', 'b', 'y', 'x' or 'w'",
-                    range[1]
-                ))
-                }
-            }
-
-            match range[1][..range[1].len() - 2].parse::<usize>() {
-                Ok(n) => end = n,
-                Err(e) => {
-                    return Err(format!(
-                        "'\x1b[1;31m{}\x1b[0m' has {}",
-                        range[1],
-                        e.to_string()
-                    ))
-                }
-            }
-
-            if start > end {
-                return Err(format!(
-                    "Start of range (\x1b[1;31m{}\x1b[0m) should be less than end (\x1b[1;31m{}\x1b[0m)",
-                    start,
-                    end,
-                ));
-            }
-
-            // put the result to vec
-            if is_line {
-                for i in start..=end {
-                    line.push((i, color));
-                }
-            } else {
-                for i in start..=end {
-                    column.push((i, color));
-                }
-            }
-        } else {
-            // part is a number
-            let num: usize;
-            let color: OutputColor;
-            if part.len() <= 2 {
-                return Err(format!("'\x1b[1;31m{}\x1b[0m' invalid format", part));
-            }
-            let last = part.chars().last();
-            let second_last = part.chars().nth(part.len() - 2);
-            let is_line: bool;
-
-            match second_last {
-                Some('l') => is_line = true,
-                Some('c') => is_line = false,
-                Some(_) => {
-                    return Err(format!(
-                        "'\x1b[1;31m{}\x1b[0m' should end with 'l' or 'c'",
-                        part
-                    ))
-                }
-                None => {
-                    return Err(format!(
-                        "'\x1b[1;31m{}\x1b[0m' lack of 'l' or 'c' to specify line or column",
-                        part
-                    ))
-                }
-            }
-
-            match last {
-                Some('r') => color = OutputColor::Red,
-                Some('g') => color = OutputColor::Green,
-                Some('b') => color = OutputColor::Blue,
-                Some('y') => color = OutputColor::Yellow,
-                Some('x') => color = OutputColor::Grey,
-                Some('w') => color = OutputColor::White,
-                _ => {
-                    return Err(format!(
-                    "'\x1b[1;31m{}\x1b[0m' should end with color 'r', 'g', 'b', 'y', 'x' or 'w'",
-                    part
-                ))
-                }
-            }
-
-            match part[..part.len() - 2].parse::<usize>() {
-                Ok(n) => num = n,
-                Err(e) => return Err(format!("'\x1b[1;31m{}\x1b[0m' has {}", part, e.to_string())),
-            }
-
-            // put the result to vec
-            if is_line {
-                line.push((num, color));
-            } else {
-                column.push((num, color));
-            }
+        } else if matches[0] == 2 {
+            let range_error = RangeError::new(
+                RangeErrorKind::LeftSideError,
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+            );
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some(range_error.message(ErrorLevel::Warning).to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        } else if matches[0] == 3 {
+            let range_error = RangeError::new(
+                RangeErrorKind::RightSideError,
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+            );
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some(range_error.message(ErrorLevel::Warning).to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        } else if matches[0] == 4 {
+            let range_error = RangeError::new(
+                RangeErrorKind::BothSidesError,
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+            );
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some(range_error.message(ErrorLevel::Warning).to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        } else if matches[0] == 5 {
+            let range_error = RangeError::new(
+                RangeErrorKind::SingleNumberError,
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+            );
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some(range_error.message(ErrorLevel::Warning).to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        } else if matches[0] == 6 || matches[0] == 7 {
+            let keyword_missing = KeywordMissing::new(
+                Some("line/column".to_string()),
+                Some("export_color".to_string()),
+                Some((location, location + part.len())),
+                "line or column".to_string(),
+            );
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some(keyword_missing.message(ErrorLevel::Warning).to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
+        } else if matches[0] == 8 {
+            let keyword_missing = KeywordMissing::new(
+                Some("color".to_string()),
+                Some("export_color".to_string()),
+                Some((location, location + part.len())),
+                "color".to_string(),
+            );
+            return Err(ArgError::new(
+                ArgErrorKind::WrongFormat,
+                Some(keyword_missing.message(ErrorLevel::Warning).to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
+                Some((location, location + part.len())),
+                None,
+            ));
         }
+        location += part.len();
     }
-    // sort the lines and columns by number
-    line.sort_by(|a, b| a.0.cmp(&b.0));
-    column.sort_by(|a, b| a.0.cmp(&b.0));
-    Ok((line, column))
+    Ok((lines, columns))
+}
+
+fn parse_range_subtable(s: &str) -> ((usize, usize), LineColumn) {
+    static RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?<start>[0-9]+)-(?<end>[0-9]+)(?<lc>[lcLC])").unwrap());
+    let caps = RE.captures(s).unwrap();
+    let start = caps["start"].parse::<usize>().unwrap();
+    let end = caps["end"].parse::<usize>().unwrap();
+    let lc = LineColumn::from_str(&caps["lc"]).unwrap();
+    ((start, end), lc)
+}
+
+fn parse_single_subtable(s: &str) -> (usize, LineColumn) {
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?<num>[0-9]+)(?<lc>[lcLC])").unwrap());
+    let caps = RE.captures(s).unwrap();
+    let num = caps["num"].parse::<usize>().unwrap();
+    let lc = LineColumn::from_str(&caps["lc"]).unwrap();
+    (num, lc)
+}
+
+fn parse_range_color(s: &str) -> ((usize, usize), OutputColor, LineColumn) {
+    static RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?<start>[0-9]+)-(?<end>[0-9]+)(?<color>[rgbyxwRGYBXW])(?<lc>[lcLC])").unwrap()
+    });
+    let caps = RE.captures(s).unwrap();
+    let start = caps["start"].parse::<usize>().unwrap();
+    let end = caps["end"].parse::<usize>().unwrap();
+    let color = OutputColor::from_str(&caps["color"]).unwrap();
+    let lc = LineColumn::from_str(&caps["lc"]).unwrap();
+    ((start, end), color, lc)
+}
+
+fn parse_single_color(s: &str) -> (usize, OutputColor, LineColumn) {
+    static RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?<num>[0-9]+)(?<color>[rgbyxwRGYBXW])(?<lc>[lcLC])").unwrap());
+    let caps = RE.captures(s).unwrap();
+    let num = caps["num"].parse::<usize>().unwrap();
+    let color = OutputColor::from_str(&caps["color"]).unwrap();
+    let lc = LineColumn::from_str(&caps["lc"]).unwrap();
+    (num, color, lc)
 }

--- a/core/src/setting/output.rs
+++ b/core/src/setting/output.rs
@@ -274,8 +274,8 @@ fn validate_export_subtable(s: &str) -> Result<(Vec<usize>, Vec<usize>), ArgErro
             ));
         } else if matches[0] == 6 || matches[0] == 7 {
             let keyword_missing = KeywordMissing::new(
-                Some("line/column".to_string()),
-                Some("export_subtable".to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
                 Some((location, location + part.len())),
                 "line or column".to_string(),
             );
@@ -420,8 +420,8 @@ fn validate_export_color(
             ));
         } else if matches[0] == 6 || matches[0] == 7 {
             let keyword_missing = KeywordMissing::new(
-                Some("line/column".to_string()),
-                Some("export_color".to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
                 Some((location, location + part.len())),
                 "line or column".to_string(),
             );
@@ -435,8 +435,8 @@ fn validate_export_color(
             ));
         } else if matches[0] == 8 {
             let keyword_missing = KeywordMissing::new(
-                Some("color".to_string()),
-                Some("export_color".to_string()),
+                Some(part.to_string()),
+                Some(s.to_string()),
                 Some((location, location + part.len())),
                 "color".to_string(),
             );


### PR DESCRIPTION
Main contents:
- Reconstructed the validate functions in `Setting` module with `regex` / by @OshinoShinobu-Chan 
- Added `Error` module with `ArgError`, `Conflicts`, and `RangeError` for various error types / by @OshinoShinobu-Chan 
- Added some tests for functions in `Setting` module: `validate_force_parse` `validate_export_subtable` and `validate_export_color` / by @ZZH-qwq 
- Bug fixes